### PR TITLE
install.sh: rename strata-core org to stratalab

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://stratadb.org/install.sh | sh
 set -eu
 
-REPO="strata-ai-labs/strata-core"
+REPO="stratalab/strata-core"
 INSTALL_DIR="${STRATA_INSTALL_DIR:-${HOME}/.strata/bin}"
 BINARY_NAME="strata"
 
@@ -253,16 +253,9 @@ print_success() {
     if [ -n "${UPDATED_CONFIG:-}" ]; then
         printf '%b\n' "  ${DIM}Restart your shell or run:${RESET}  source ${UPDATED_CONFIG}"
         printf '%b\n' ""
-        printf '%b\n' "  ${DIM}Then try:${RESET}"
-    else
-        printf '%b\n' "  ${DIM}Try:${RESET}"
     fi
 
-    printf '%b\n' ""
-    printf '%b\n' "    ${CYAN}strata${RESET}                             Open the interactive REPL"
-    printf '%b\n' "    ${CYAN}strata kv put greeting \"hello world\"${RESET}  Store your first key-value pair"
-    printf '%b\n' "    ${CYAN}strata kv get greeting${RESET}              Read it back"
-    printf '%b\n' "    ${CYAN}strata ai${RESET}                          Start the AI agent ${DIM}(requires ANTHROPIC_API_KEY)${RESET}"
+    printf '%b\n' "  ${DIM}Run ${CYAN}strata init${RESET}${DIM} to set up your first database.${RESET}"
     printf '%b\n' ""
     printf '%b\n' "  ${DIM}Docs: https://stratadb.org/docs${RESET}"
     printf '%b\n' ""


### PR DESCRIPTION
## Summary

- Update `REPO` in `public/install.sh` from the old `strata-ai-labs/strata-core` to `stratalab/strata-core`. The strata-core repo moved orgs and the GitHub redirect for the releases API endpoint is fragile to depend on long-term.
- Drop the four-line REPL/examples block at the bottom of `print_success()` in favour of a single `strata init` hint, matching the simpler post-install flow we're standardising on. (This part is a pre-existing local edit; bundling it in.)

After this lands, `curl -fsSL https://stratadb.org/install.sh | sh` will resolve directly to the new org's `releases/latest` without hitting the redirect.

## Test plan

- [ ] `bash -n public/install.sh` (syntax check)
- [ ] `STRATA_INSTALL_DIR=/tmp/strata-test sh public/install.sh` against the live releases endpoint, confirm a binary lands
- [ ] Confirm `/tmp/strata-test/strata --version` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)